### PR TITLE
Add documentation for Markdown settings

### DIFF
--- a/input/guide/content-and-data/template-languages/markdown.md
+++ b/input/guide/content-and-data/template-languages/markdown.md
@@ -1,9 +1,5 @@
 ﻿In Statiq Web and Statiq Docs, the Markdown engine is executed automatically for Markdown file types. In Statiq Framework you must use the `RenderMarkdown` module from the `Statiq.Markdown` package in your pipeline to render Markdown content.
 
-The `Statiq.Markdown` package uses [Markdig](https://github.com/xoofx/markdig) to process the Markdown,
-which is a CommonMark compliant Markdown process with additional features like support for
-GitHub Flavored Markdown fenced code blocks.
-
 # Pass Through Content
 
 You can use the special "raw" language to output verbatim content that isn't subject to Markdown processing. This is helpful when you have raw HTML and other content that you want to pass-through the Markdown engine. While using HTML elements in Markdown also accomplishes a single goal, it has some limitations like breaking when new lines are included.
@@ -22,3 +18,5 @@ will pass-through.
 </code></pre>
 ?>
 <?#/ Raw ?>
+
+[Markdig extensions]: https://github.com/xoofx/markdig/blob/master/readme.md


### PR DESCRIPTION
Add documentation for Markdown settings and how to enable Markdown extensions

Fixes remaining open parts of https://github.com/statiqdev/Statiq.Framework/issues/222